### PR TITLE
Review and integrate pr with latest improvements

### DIFF
--- a/src/amas/core/unified_orchestrator_v2.py
+++ b/src/amas/core/unified_orchestrator_v2.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Callable
 
 from amas.common.models import OrchestratorTask, TaskPriority, TaskStatus, AgentConfig, AgentStatus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,9 +85,6 @@ def mock_service_manager(mock_vector_service, mock_knowledge_graph_service):
 
 @pytest.fixture
 async def mock_orchestrator(mock_universal_ai_manager, mock_service_manager, mock_message_bus):
-
-
-
     """
     Mock UnifiedOrchestratorV2 instance with mocked dependencies.
     """
@@ -124,41 +121,37 @@ def mock_task():
 
 @pytest.fixture
 async def rag_agent(mock_orchestrator, mock_message_bus, agent_config):
-    orchestrator = await mock_orchestrator
     """RAGAgent instance for testing."""
+    orchestrator = await mock_orchestrator
     agent = RAGAgent("rag_agent_001", agent_config, orchestrator, mock_message_bus)
-
     return agent
 
 @pytest.fixture
 async def tool_agent(mock_orchestrator, mock_message_bus, agent_config):
-    orchestrator = await mock_orchestrator
     """ToolAgent instance for testing."""
+    orchestrator = await mock_orchestrator
     agent = ToolAgent("tool_agent_001", agent_config, orchestrator, mock_message_bus)
-
     return agent
 
 @pytest.fixture
 async def planning_agent(mock_orchestrator, mock_message_bus, agent_config):
-    orchestrator = await mock_orchestrator
     """PlanningAgent instance for testing."""
+    orchestrator = await mock_orchestrator
     agent = PlanningAgent("planning_agent_001", agent_config, orchestrator, mock_message_bus)
-
     return agent
 
 @pytest.fixture
 async def code_agent(mock_orchestrator, mock_message_bus, agent_config):
-    orchestrator = await mock_orchestrator
     """CodeAgent instance for testing."""
+    orchestrator = await mock_orchestrator
     agent = CodeAgent("code_agent_001", agent_config, orchestrator, mock_message_bus)
     return agent
 
 @pytest.fixture
 async def data_agent(mock_orchestrator, mock_message_bus, agent_config):
-    orchestrator = await mock_orchestrator
     """DataAgent instance for testing."""
+    orchestrator = await mock_orchestrator
     agent = DataAgent("data_agent_001", agent_config, orchestrator, mock_message_bus)
-
     return agent
 
 


### PR DESCRIPTION
Integrate PR #157's test suite fixes and orchestrator improvements by adding a missing `datetime` import and refining async fixtures.

The changes ensure that `unified_orchestrator_v2.py` correctly handles `datetime` objects and that `conftest.py`'s async agent fixtures properly await the `mock_orchestrator` fixture, resolving potential runtime warnings and aligning with the intended async test structure from PR #157.

---
<a href="https://cursor.com/background-agent?bcId=bc-80e8ae86-bebe-4571-a9bd-fa43bd0d6c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80e8ae86-bebe-4571-a9bd-fa43bd0d6c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

