### PR TITLE
Fix ci pipeline add python ensurepip

### DIFF
--- a/.github/workflows/advanced-multi-agent-orchestration.yml
+++ b/.github/workflows/advanced-multi-agent-orchestration.yml
@@ -62,7 +62,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install advanced dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         pip install openai aiohttp asyncio requests pyyaml
         pip install python-dotenv PyGithub gitpython

--- a/.github/workflows/ai-adaptive-prompt-improvement.yml
+++ b/.github/workflows/ai-adaptive-prompt-improvement.yml
@@ -30,7 +30,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai-code-analysis.yml
+++ b/.github/workflows/ai-code-analysis.yml
@@ -47,7 +47,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests
     

--- a/.github/workflows/ai-enhanced-code-review.yml
+++ b/.github/workflows/ai-enhanced-code-review.yml
@@ -29,7 +29,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai-enhanced-workflow.yml
+++ b/.github/workflows/ai-enhanced-workflow.yml
@@ -37,7 +37,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests
     
@@ -112,7 +115,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests
     
@@ -162,7 +168,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install "openai>=0.27.0" requests
     

--- a/.github/workflows/ai-incident-response.yml
+++ b/.github/workflows/ai-incident-response.yml
@@ -30,7 +30,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai-issue-responder.yml
+++ b/.github/workflows/ai-issue-responder.yml
@@ -39,7 +39,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests
     

--- a/.github/workflows/ai-master-orchestrator.yml
+++ b/.github/workflows/ai-master-orchestrator.yml
@@ -32,6 +32,7 @@ jobs:
     
     - name: Install dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai-osint-collection.yml
+++ b/.github/workflows/ai-osint-collection.yml
@@ -30,7 +30,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests beautifulsoup4 feedparser
     

--- a/.github/workflows/ai-security-response.yml
+++ b/.github/workflows/ai-security-response.yml
@@ -30,7 +30,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai-threat-intelligence.yml
+++ b/.github/workflows/ai-threat-intelligence.yml
@@ -30,7 +30,10 @@ jobs:
         python-version: '3.11'
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install openai requests python-dotenv
     

--- a/.github/workflows/ai_complete_workflow.yml
+++ b/.github/workflows/ai_complete_workflow.yml
@@ -53,7 +53,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -100,7 +101,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -165,7 +167,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -231,7 +234,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -305,7 +309,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -378,7 +383,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -469,7 +475,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -536,7 +543,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -610,7 +618,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 

--- a/.github/workflows/ai_development.yml
+++ b/.github/workflows/ai_development.yml
@@ -40,7 +40,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -88,7 +89,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -157,7 +159,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -233,7 +236,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -292,7 +296,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -357,7 +362,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -426,7 +432,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 

--- a/.github/workflows/ai_simple_workflow.yml
+++ b/.github/workflows/ai_simple_workflow.yml
@@ -33,7 +33,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -242,7 +243,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -288,7 +290,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -334,7 +337,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -380,7 +384,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -426,7 +431,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 
@@ -478,7 +484,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Install dependencies
-      run: 'python -m pip install --upgrade pip
+  run: \'python -m ensurepip --upgrade
+    python -m pip install --upgrade pip
 
         pip install --upgrade -r requirements.txt
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,6 +37,7 @@ jobs:
     
     - name: 📦 Install dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         pip install -e .[dev]
     
@@ -116,6 +117,7 @@ jobs:
     
     - name: 📦 Install dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         pip install -e .[dev]
     
@@ -227,6 +229,7 @@ jobs:
     
     - name: 📦 Install test dependencies
       run: |
+        python -m ensurepip --upgrade
         pip install -e .[dev]
     
     - name: 🎭 Run E2E tests
@@ -277,6 +280,7 @@ jobs:
     
     - name: ⚡ Run performance tests
       run: |
+        python -m ensurepip --upgrade
         pip install locust
         locust -f tests/performance/load_test.py --host=http://localhost:8000 --users=50 --spawn-rate=5 --run-time=5m --html=performance-report.html --csv=performance
     
@@ -309,6 +313,7 @@ jobs:
     
     - name: 📦 Install documentation dependencies
       run: |
+        python -m ensurepip --upgrade
         pip install -e .[docs]
     
     - name: 📖 Build documentation
@@ -344,6 +349,7 @@ jobs:
     
     - name: 📦 Install build dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip build twine
     
     - name: 🏗️ Build package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install setuptools wheel
           pip install -r requirements.txt
@@ -68,6 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install setuptools wheel
           pip install -r requirements.txt
@@ -139,6 +141,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install setuptools wheel
           pip install -r requirements.txt
@@ -173,6 +176,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install bandit safety

--- a/.github/workflows/comprehensive-ai-integration.yml
+++ b/.github/workflows/comprehensive-ai-integration.yml
@@ -65,7 +65,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install comprehensive dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         pip install openai aiohttp asyncio requests pyyaml
         pip install python-dotenv PyGithub gitpython

--- a/.github/workflows/enhanced-ai-issue-responder.yml
+++ b/.github/workflows/enhanced-ai-issue-responder.yml
@@ -55,7 +55,10 @@ jobs:
         cache: 'pip'
     
     - name: 📦 Install dependencies with caching
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
         if [ -f requirements.txt ]; then

--- a/.github/workflows/multi-agent-workflow.yml
+++ b/.github/workflows/multi-agent-workflow.yml
@@ -33,7 +33,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install dependencies
-      run: |
+      run: |      python -m ensurepip --upgrade
+        python -m pip install --upgrade pippython -m ensurepip --upgrade
+
+
         python -m pip install --upgrade pip
         python -m pip install "openai>=0.27.0" requests
     

--- a/.github/workflows/python-dependency-submission.yml
+++ b/.github/workflows/python-dependency-submission.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Upgrade pip, setuptools and wheel
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip setuptools wheel pip-tools
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
     
     - name: 📦 Install dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         pip install requests pyyaml setuptools wheel
         pip install -e .

--- a/.github/workflows/test-ai-workflow.yml
+++ b/.github/workflows/test-ai-workflow.yml
@@ -21,6 +21,7 @@ jobs:
     
     - name: Install dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         python -m pip install openai requests
     

--- a/.github/workflows/ultimate_ai_workflow.yml
+++ b/.github/workflows/ultimate_ai_workflow.yml
@@ -56,6 +56,7 @@ jobs:
     
     - name: Install Ultimate Dependencies
       run: |
+        python -m ensurepip --upgrade
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install openai aiohttp python-dotenv requests pyyaml

--- a/.github/workflows/universal-ai-workflow.yml
+++ b/.github/workflows/universal-ai-workflow.yml
@@ -55,6 +55,7 @@ jobs:
       
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           pip install aiohttp asyncio
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi


### PR DESCRIPTION
Add `python -m ensurepip --upgrade` to all Python-based GitHub Actions workflows to ensure pip is available for installations.

Many CI environments install Python without `pip` or with an outdated `pip`. This change ensures that `pip` is properly installed and upgraded before any `pip install` commands are executed, preventing common CI failures related to missing or broken `pip`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a564a632-d806-409f-97f9-2457c598384e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a564a632-d806-409f-97f9-2457c598384e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

